### PR TITLE
FIX: OpenSSH backend won't start for non-root users under debian stable

### DIFF
--- a/lib/Test/SSH/Backend/OpenSSH.pm
+++ b/lib/Test/SSH/Backend/OpenSSH.pm
@@ -35,7 +35,8 @@ sub new {
                          PidFile            => "$run_dir/sshd.pid",
                          PrintLastLog       => 'no',
                          PrintMotd          => 'no',
-                         UseDNS             => 'no')
+                         UseDNS             => 'no',
+                         UsePrivilegeSeparation => 'no')
         or return;
 
     $sshd->_log('starting SSH server');


### PR DESCRIPTION
Hi.

This patch fixes an issue where Test:SSH won't run with the openssh backend for non root users. This affects current stable debian and (I assume) other recent distros. Basically sshd gets upset at the lack of a privilege separation directory, this invokes without that option.

This branch comes from before your commit "working on running remote command with plink " as that breaks everything for me.
